### PR TITLE
Allow ModelConstructor type to be used in app.

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -11,7 +11,7 @@ interface Graph {
     };
 }
 
-type ModelConstructor = { new(data: JsonApiResource, store?: Store): Model };
+export type ModelConstructor = { new(data: JsonApiResource, store?: Store): Model };
 
 interface ModelCollection {
     [type: string]: ModelConstructor;


### PR DESCRIPTION
This is very useful when constructing own api call. I use this type like `async fetchOne(model: ModelConstructor | string)`.