### PR TITLE
adds exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "license": "MIT",
     "module": "./dist/index.es.js",
     "types": "./dist/index.d.ts",
+    "exports": {
+        "import": "./dist/index.es.js",
+        "types": "./dist/index.d.ts"
+    },
     "files": [
         "src",
         "dist",


### PR DESCRIPTION
Hello,

I'm currently developing an app with Vite and doing testing with Vitest. When running tests the following error appears in the console:
`Error: Failed to resolve entry for package "json-api-models". The package may have incorrect main/module/exports specified in its package.json.`
More info on why this happens [here](https://github.com/vitest-dev/vitest/discussions/4233).
By adding this field the error is resolved and the tests run normally.